### PR TITLE
Correct use postgres memory functions

### DIFF
--- a/expected/pg_climb.out
+++ b/expected/pg_climb.out
@@ -60,3 +60,12 @@ SELECT grade, grade_type(grade) FROM grades_unique;
  5.10a | yds
 (6 rows)
 
+-- grade[] should work
+CREATE TABLE grades_array(grade grade[]);
+INSERT INTO grades_array VALUES (ARRAY['V5'::grade, 'F7A+'::grade]);
+SELECT * FROM grades_array;
+   grade   
+-----------
+ {V5,F7A+}
+(1 row)
+

--- a/pg_climb_module.c
+++ b/pg_climb_module.c
@@ -36,6 +36,7 @@ GRADE_in(PG_FUNCTION_ARGS)
 {
 	Grade	*grade;
 	SerializedGrade	*serialized = NULL;
+	SerializedGrade	*pg_serialized = NULL;
 	char	*input = PG_GETARG_CSTRING(0);
 	int32_t	typmod = -1;
 	size_t	size;
@@ -51,21 +52,23 @@ GRADE_in(PG_FUNCTION_ARGS)
 
 	grade = grade_from_string(input, typmod < 0 ? ANYTYPE : (uint32_t)typmod);
 
-	if (grade) {
-		serialized = serialized_grade_from_grade(grade, &size);
-
-		// insert postgres size header
-		serialized = realloc(serialized, size + VARHDRSZ);
-		memmove((uint8_t*)serialized + VARHDRSZ, serialized, size);
-		SET_VARSIZE(serialized, size + VARHDRSZ);
-
-		grade_free(grade);
-	} else {
+	if (!grade) {
 		ereport(ERROR,(errmsg("parse error - invalid grade")));
 		PG_RETURN_NULL();
 	}
 
-	PG_RETURN_SERGRADE_P(serialized);
+	serialized = serialized_grade_from_grade(grade, &size);
+
+	// copy to pg context
+	pg_serialized = (SerializedGrade *) palloc(size + VARHDRSZ);
+	SET_VARSIZE(pg_serialized, size + VARHDRSZ);
+	// TODO memmove is unecessary _if_ the memory won't overlap
+	memmove((uint8_t*)pg_serialized + VARHDRSZ, serialized, size);
+
+	grade_free(grade);
+	free(serialized);
+
+	PG_RETURN_SERGRADE_P(pg_serialized);
 }
 
 PG_FUNCTION_INFO_V1(GRADE_out);
@@ -74,15 +77,20 @@ Datum
 GRADE_out(PG_FUNCTION_ARGS)
 {
 	SerializedGrade	*serialized = PG_GETARG_SERGRADE_P(0);
-	// TODO is this leaky?
 	Grade *grade = grade_from_serialized(serialized);
+	char *raw;
+	char *pgstr;
 
 	if (!grade)
 		ereport(ERROR,(errmsg("Failed to deserialized grade data")));
 
-	// TODO would it be a better API to allocate the string here and just
-	// format it?
-	PG_RETURN_CSTRING(grade_to_string(grade));
+	raw = grade_to_string(grade);
+	pgstr = pstrdup(raw);
+
+	free(raw);
+	grade_free(grade);
+
+	PG_RETURN_CSTRING(pgstr);
 }
 
 PG_FUNCTION_INFO_V1(GRADE_typmod_in);

--- a/pg_climb_module.c
+++ b/pg_climb_module.c
@@ -166,8 +166,8 @@ GRADE_enforce_typmod(PG_FUNCTION_ARGS)
 	void *ret;
 
 	// TODO this is a little ugly, but it gets the job done for now
-	ret = PG_GETARG_SERGRADE_P(0) - VARHDRSZ;
-	serialized = (SerializedGrade *)ret + VARHDRSZ;
+	ret = ((char *)PG_GETARG_SERGRADE_P(0) - VARHDRSZ);
+	serialized = (SerializedGrade *)((char *)ret + VARHDRSZ);
 
 	typmod = PG_GETARG_INT32(1);
 
@@ -194,13 +194,13 @@ Datum
 GRADE_lt(PG_FUNCTION_ARGS)
 {
 	int cmp;
-	void *g1;
-	void *g2;
+	char *g1;
+	char *g2;
 
 	// TODO this is a little ugly, but it gets the job done for now
-	g1 = PG_GETARG_SERGRADE_P(0) - VARHDRSZ;
-	g2 = PG_GETARG_SERGRADE_P(1) - VARHDRSZ;
-	cmp = serialized_grade_cmp((SerializedGrade*)g1 + VARHDRSZ, (SerializedGrade*)g2 + VARHDRSZ);
+	g1 = (char *)PG_GETARG_SERGRADE_P(0) - VARHDRSZ;
+	g2 = (char *)PG_GETARG_SERGRADE_P(1) - VARHDRSZ;
+	cmp = serialized_grade_cmp((SerializedGrade*)(g1 + VARHDRSZ), (SerializedGrade*)(g2 + VARHDRSZ));
 
 	PG_FREE_IF_COPY(g1, 0);
 	PG_FREE_IF_COPY(g2, 1);
@@ -213,13 +213,13 @@ Datum
 GRADE_le(PG_FUNCTION_ARGS)
 {
 	int cmp;
-	void *g1;
-	void *g2;
+	char *g1;
+	char *g2;
 
 	// TODO this is a little ugly, but it gets the job done for now
-	g1 = PG_GETARG_SERGRADE_P(0) - VARHDRSZ;
-	g2 = PG_GETARG_SERGRADE_P(1) - VARHDRSZ;
-	cmp = serialized_grade_cmp((SerializedGrade*)g1 + VARHDRSZ, (SerializedGrade*)g2 + VARHDRSZ);
+	g1 = (char *)PG_GETARG_SERGRADE_P(0) - VARHDRSZ;
+	g2 = (char *)PG_GETARG_SERGRADE_P(1) - VARHDRSZ;
+	cmp = serialized_grade_cmp((SerializedGrade*)(g1 + VARHDRSZ), (SerializedGrade*)(g2 + VARHDRSZ));
 
 	PG_FREE_IF_COPY(g1, 0);
 	PG_FREE_IF_COPY(g2, 1);
@@ -232,13 +232,13 @@ Datum
 GRADE_eq(PG_FUNCTION_ARGS)
 {
 	int cmp;
-	void *g1;
-	void *g2;
+	char *g1;
+	char *g2;
 
 	// TODO this is a little ugly, but it gets the job done for now
-	g1 = PG_GETARG_SERGRADE_P(0) - VARHDRSZ;
-	g2 = PG_GETARG_SERGRADE_P(1) - VARHDRSZ;
-	cmp = serialized_grade_cmp((SerializedGrade*)g1 + VARHDRSZ, (SerializedGrade*)g2 + VARHDRSZ);
+	g1 = (char *)PG_GETARG_SERGRADE_P(0) - VARHDRSZ;
+	g2 = (char *)PG_GETARG_SERGRADE_P(1) - VARHDRSZ;
+	cmp = serialized_grade_cmp((SerializedGrade*)(g1 + VARHDRSZ), (SerializedGrade*)(g2 + VARHDRSZ));
 
 	PG_FREE_IF_COPY(g1, 0);
 	PG_FREE_IF_COPY(g2, 1);
@@ -251,13 +251,13 @@ Datum
 GRADE_neq(PG_FUNCTION_ARGS)
 {
 	int cmp;
-	void *g1;
-	void *g2;
+	char *g1;
+	char *g2;
 
 	// TODO this is a little ugly, but it gets the job done for now
-	g1 = PG_GETARG_SERGRADE_P(0) - VARHDRSZ;
-	g2 = PG_GETARG_SERGRADE_P(1) - VARHDRSZ;
-	cmp = serialized_grade_cmp((SerializedGrade*)g1 + VARHDRSZ, (SerializedGrade*)g2 + VARHDRSZ);
+	g1 = (char *)PG_GETARG_SERGRADE_P(0) - VARHDRSZ;
+	g2 = (char *)PG_GETARG_SERGRADE_P(1) - VARHDRSZ;
+	cmp = serialized_grade_cmp((SerializedGrade*)(g1 + VARHDRSZ), (SerializedGrade*)(g2 + VARHDRSZ));
 
 	PG_FREE_IF_COPY(g1, 0);
 	PG_FREE_IF_COPY(g2, 1);
@@ -270,13 +270,13 @@ Datum
 GRADE_ge(PG_FUNCTION_ARGS)
 {
 	int cmp;
-	void *g1;
-	void *g2;
+	char *g1;
+	char *g2;
 
 	// TODO this is a little ugly, but it gets the job done for now
-	g1 = PG_GETARG_SERGRADE_P(0) - VARHDRSZ;
-	g2 = PG_GETARG_SERGRADE_P(1) - VARHDRSZ;
-	cmp = serialized_grade_cmp((SerializedGrade*)g1 + VARHDRSZ, (SerializedGrade*)g2 + VARHDRSZ);
+	g1 = (char *)PG_GETARG_SERGRADE_P(0) - VARHDRSZ;
+	g2 = (char *)PG_GETARG_SERGRADE_P(1) - VARHDRSZ;
+	cmp = serialized_grade_cmp((SerializedGrade*)(g1 + VARHDRSZ), (SerializedGrade*)(g2 + VARHDRSZ));
 
 	PG_FREE_IF_COPY(g1, 0);
 	PG_FREE_IF_COPY(g2, 1);
@@ -289,13 +289,13 @@ Datum
 GRADE_gt(PG_FUNCTION_ARGS)
 {
 	int cmp;
-	void *g1;
-	void *g2;
+	char *g1;
+	char *g2;
 
 	// TODO this is a little ugly, but it gets the job done for now
-	g1 = PG_GETARG_SERGRADE_P(0) - VARHDRSZ;
-	g2 = PG_GETARG_SERGRADE_P(1) - VARHDRSZ;
-	cmp = serialized_grade_cmp((SerializedGrade*)g1 + VARHDRSZ, (SerializedGrade*)g2 + VARHDRSZ);
+	g1 = (char *)PG_GETARG_SERGRADE_P(0) - VARHDRSZ;
+	g2 = (char *)PG_GETARG_SERGRADE_P(1) - VARHDRSZ;
+	cmp = serialized_grade_cmp((SerializedGrade*)(g1 + VARHDRSZ), (SerializedGrade*)(g2 + VARHDRSZ));
 
 	PG_FREE_IF_COPY(g1, 0);
 	PG_FREE_IF_COPY(g2, 1);
@@ -308,13 +308,13 @@ Datum
 GRADE_cmp(PG_FUNCTION_ARGS)
 {
 	int cmp;
-	void *g1;
-	void *g2;
+	char *g1;
+	char *g2;
 
 	// TODO this is a little ugly, but it gets the job done for now
-	g1 = PG_GETARG_SERGRADE_P(0) - VARHDRSZ;
-	g2 = PG_GETARG_SERGRADE_P(1) - VARHDRSZ;
-	cmp = serialized_grade_cmp((SerializedGrade*)g1 + VARHDRSZ, (SerializedGrade*)g2 + VARHDRSZ);
+	g1 = (char *)PG_GETARG_SERGRADE_P(0) - VARHDRSZ;
+	g2 = (char *)PG_GETARG_SERGRADE_P(1) - VARHDRSZ;
+	cmp = serialized_grade_cmp((SerializedGrade*)(g1 + VARHDRSZ), (SerializedGrade*)(g2 + VARHDRSZ));
 
 	PG_FREE_IF_COPY(g1, 0);
 	PG_FREE_IF_COPY(g2, 1);
@@ -330,11 +330,11 @@ GRADE_type(PG_FUNCTION_ARGS)
 	SerializedGrade *serialized;
 	char *type_str;
 	text *type_text;
-	void *bytes;
+	char *bytes;
 
 	// TODO this is a little ugly, but it gets the job done for now
-	bytes = PG_GETARG_SERGRADE_P(0) - VARHDRSZ;
-	serialized = (SerializedGrade *)bytes + VARHDRSZ;
+	bytes = (char *)PG_GETARG_SERGRADE_P(0) - VARHDRSZ;
+	serialized = (SerializedGrade *)(bytes + VARHDRSZ);
 	grade = grade_from_serialized(serialized);
 
         // NOTE Grade.type _is_ typmod for valid types (for now)

--- a/sql/pg_climb.sql
+++ b/sql/pg_climb.sql
@@ -31,3 +31,8 @@ SELECT grade from grades_unique ORDER BY grade;
 
 -- the types can be gotten by calling the grade_type function
 SELECT grade, grade_type(grade) FROM grades_unique;
+
+-- grade[] should work
+CREATE TABLE grades_array(grade grade[]);
+INSERT INTO grades_array VALUES (ARRAY['V5'::grade, 'F7A+'::grade]);
+SELECT * FROM grades_array;


### PR DESCRIPTION
Also does some pointer-math fixing.. during the coding session for this I realized a couple things

- We should use `struct varlena`, it comes with its own `PG_GET` macros, so I don't need to have custom ones for `SerializedGrade` (though I can, if I wanted, and I they can use the varlena ones internally.
- I should really avoid implementing `SerializedGrade` in `pg_climb.c`, that seems like a job for `pg_climb_module.c`.. because serialization, especially into a specific format (`struct varlena`), should be scoped to the thing owning that format. In this case, that would be the _module.c file, as that is the only file that deals with PostgreSQL itself.

Fixes #2